### PR TITLE
Add nix-systems input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,7 +56,23 @@
       "inputs": {
         "filestash": "filestash",
         "nixpkgs": "nixpkgs",
-        "parts": "parts"
+        "parts": "parts",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,17 +9,14 @@
       url = github:mickael-kerjean/filestash;
       flake = false;
     };
+    systems.url = github:nix-systems/default;
   };
 
-  outputs = inputs @ {parts, ...}:
+  outputs = inputs @ {parts, systems, ...}:
     parts.lib.mkFlake {
       inherit inputs;
     } ({lib, ...}: {
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
-      ];
+      systems = import systems;
 
       imports = [
         ./packages.nix

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,11 @@
     systems.url = github:nix-systems/default;
   };
 
-  outputs = inputs @ {parts, systems, ...}:
+  outputs = inputs @ {
+    parts,
+    systems,
+    ...
+  }:
     parts.lib.mkFlake {
       inherit inputs;
     } ({lib, ...}: {


### PR DESCRIPTION
This adds https://github.com/nix-systems/default as an input to make the systems specified by this flake extensible by consumer flakes.